### PR TITLE
Replace cask by brew installation on some packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/aws.yml
+++ b/aws.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: 127.0.0.1
+- hosts: localhost
   connection: local
   roles:
     - profile-all

--- a/roles/profile-dev-aws/tasks/main.yml
+++ b/roles/profile-dev-aws/tasks/main.yml
@@ -5,13 +5,13 @@
   with_items:
     - wget
     - awscli
+    - python3
+    - python
+    - terraform
+    - packer
 
 - name: install AWS-specific dev cask applications
   homebrew_cask: name={{item}} state=present
   with_items:
-    - python3
     - vagrant
     - virtualbox
-    - python
-    - packer
-    - terraform


### PR DESCRIPTION
**Solve issue FND-138**
Change superlumic package config items to use brew instead of cask since some packages dont exist in cask
- Replace cask by brew installation on some packages
- Fix config task aws yaml to use localhost instead of 127.0.0.1. This prevented package installtion
