### PR TITLE
Updating Minikube and Kubectl versions.

### DIFF
--- a/roles/profile-dev/tasks/main.yml
+++ b/roles/profile-dev/tasks/main.yml
@@ -17,10 +17,10 @@
     - jq
 
 - name: Download and place minikube in proper path
-  get_url: url="https://storage.googleapis.com/minikube/releases/v{{ minikube_version }}/minikube-darwin-amd64" dest=/usr/local/bin/minikube mode=0755
+  get_url: url="https://storage.googleapis.com/minikube/releases/v{{ minikube_version }}/minikube-darwin-amd64" dest=/usr/local/bin/minikube mode=0755 checksum="{{minikube_checksum}}"
 
 - name: Download and place kubectl in proper path
-  get_url: url="https://storage.googleapis.com/kubernetes-release/release/v{{ kubectl_version }}/bin/darwin/amd64/kubectl" dest=/usr/local/bin/kubectl mode=0755
+  get_url: url="https://storage.googleapis.com/kubernetes-release/release/v{{ kubectl_version }}/bin/darwin/amd64/kubectl" dest=/usr/local/bin/kubectl mode=0755 checksum="{{kubectl_checksum}}"
 
 - name: install dev cask applications
   homebrew_cask: name={{item}} state=present
@@ -36,3 +36,4 @@
     - postman
     - sourcetree
     - gitx
+

--- a/roles/profile-dev/vars/main.yml
+++ b/roles/profile-dev/vars/main.yml
@@ -1,6 +1,6 @@
 ---
-kubectl_version: "1.4.0"
-kubectl_checksum: "sha256:c9945d10a1c322861796d4ecc3934330b50a8225cdfab33665fbf401d538e7dc"
+kubectl_version: "1.4.4"
+kubectl_checksum: "sha256:5940c5d32e33a1c0b42998083064112f6ea7f02d9dc5e2b4f51c01f583a6be4d."
 
-minikube_version: "0.11.0"
-minikube_checksum: "sha256:7fe7ce35eda959d91071d065141d040053b945d5af0d57f98eb18afb93a4c921"
+minikube_version: "0.12.0"
+minikube_checksum: "sha256:a96d6e1d53a7999503d00bcd41b4ccaa80f5d57f798608f03e3f4d63a42f9991."

--- a/roles/profile-dev/vars/main.yml
+++ b/roles/profile-dev/vars/main.yml
@@ -1,6 +1,6 @@
 ---
-kubectl_version: "1.3.0"
-kubectl_checksum: "BA0720FF87A801FE96CB1E673074C429"
+kubectl_version: "1.4.0"
+kubectl_checksum: "sha256:c9945d10a1c322861796d4ecc3934330b50a8225cdfab33665fbf401d538e7dc"
 
-minikube_version: "0.6.0"
-minikube_checksum: "444BEF29D0A0D7FBB340C73560EC0773"
+minikube_version: "0.11.0"
+minikube_checksum: "sha256:7fe7ce35eda959d91071d065141d040053b945d5af0d57f98eb18afb93a4c921"


### PR DESCRIPTION
- Kubectl version updated to 1.4.0
- Minikube updated to 0.11.0 which is compatible with 1.4.0
- Restored the SHA256 checks which appear to have gotten removed at some point.
